### PR TITLE
✨ 修复打开管理页面无法跳转

### DIFF
--- a/luasrc/view/baidupcs-web/baidupcs-web_status.htm
+++ b/luasrc/view/baidupcs-web/baidupcs-web_status.htm
@@ -24,7 +24,7 @@ function openClient() {
 	var pathName = window.document.location.pathname;
 	var pos = curWwwPath.indexOf(pathName);
 	var localhostPath = curWwwPath.substring(0, pos);
-	var clientPort = window.document.getElementById("cbid.baidupcs-web.config.port").value
+	var clientPort = window.document.getElementById("widget.cbid.baidupcs-web.config.port").value
 	var url = "http:" + localhostPath.substring(window.location.protocol.length) + ":" + clientPort;
 	window.open(url)
 };


### PR DESCRIPTION
- 问题：打开管理页面按钮无法跳转
- 原因：获取端口号的id与输入框组件id不对应
- 解决办法：修改为对应id